### PR TITLE
added drupal-lenient to allow d9 modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "drupal/core-recommended": "10.0.0",
         "drupal/lagoon_logs": "2.1.1",
         "drush/drush": "11.4.0",
+        "mglaman/composer-drupal-lenient": "^1.0",
         "zaporylie/composer-drupal-optimizations": "1.2.0"
     },
     "require-dev": {
@@ -44,7 +45,8 @@
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
             "phpstan/extension-installer": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "mglaman/composer-drupal-lenient": true
         }
     },
     "extra": {
@@ -67,6 +69,10 @@
             },
             "locations": {
                 "web-root": "web/"
+            }
+        },
+        "drupal-lenient": {
+            "allowed-list": {
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae3564eb748c59c7b7a6e9e3a626b5e4",
+    "content-hash": "ee7c02de1badf676d8af8079657a75e5",
     "packages": [
         {
             "name": "amazeeio/drupal_integrations",
@@ -2394,6 +2394,58 @@
                 "source": "https://github.com/Masterminds/html5-php/tree/2.7.6"
             },
             "time": "2022-08-18T16:18:26+00:00"
+        },
+        {
+            "name": "mglaman/composer-drupal-lenient",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mglaman/composer-drupal-lenient.git",
+                "reference": "97ffd460705b4f7177519b3e29cdee4549f42e15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mglaman/composer-drupal-lenient/zipball/97ffd460705b4f7177519b3e29cdee4549f42e15",
+                "reference": "97ffd460705b4f7177519b3e29cdee4549f42e15",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "composer/composer": "^2.3",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.6",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "ComposerDrupalLenient\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "ComposerDrupalLenient\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Glaman",
+                    "email": "nmd.matt@gmail.com"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/mglaman/composer-drupal-lenient/issues",
+                "source": "https://github.com/mglaman/composer-drupal-lenient/tree/1.0.2"
+            },
+            "time": "2022-06-24T20:50:05+00:00"
         },
         {
             "name": "monolog/monolog",


### PR DESCRIPTION
Adding this module to composer.json allows install of non-d10 compatible modules in composer.json by rewriting the drupal/core constraint prior to composer considering it.

See https://github.com/mglaman/composer-drupal-lenient for more information