### PR TITLE
Additional docker-compose file just for Lando to fix the additional_contexts issue

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,5 +2,19 @@ name: drupalnext-base
 recipe: lagoon
 config:
   flavor: drupal
+  webroot: web
   compose:
     - docker-compose.lando.yml
+
+events:
+  post-start:
+    - |
+      if [ ! -d vendor ]; then
+        echo "Running composer install..."
+        composer install
+      else
+        echo "Vendor folder exists; skipping composer install."
+      fi
+
+
+

--- a/docker-compose.lando.yml
+++ b/docker-compose.lando.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: lagoon/nginx.dockerfile
       args:
         CLI_IMAGE: ${COMPOSE_PROJECT_NAME:-drupalnext-base}-cli
+    additional_contexts: null
 
   php:
     build:
@@ -12,4 +13,4 @@ services:
       dockerfile: lagoon/php.dockerfile
       args:
         CLI_IMAGE: ${COMPOSE_PROJECT_NAME:-drupalnext-base}-cli
-
+    additional_contexts: null


### PR DESCRIPTION
Pygmy users will run docker compose with the base docker-compose.yml, no change, everything works with additional_contexts.

For Lando users, it will load both docker-compose.yml and docker-compose.lando.yml.

The override replaces the build blocks for php and nginx.
This strips the additional_contexts that break Lando, but keeps the CLI_IMAGE arg wiring.